### PR TITLE
Create VM instance with firewall and custom VPC

### DIFF
--- a/vm-instance.tf
+++ b/vm-instance.tf
@@ -1,0 +1,112 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+variable "project_id" {
+  description = "The ID of the project in which the resource belongs."
+  type        = string
+}
+
+variable "region" {
+  description = "The region in which resources will be created."
+  type        = string
+  default     = "us-central1"
+}
+
+resource "google_project_service" "compute_api" {
+  project = var.project_id
+  service = "compute.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_compute_network" "vpc_network" {
+  name = "custom-vpc-network"
+  auto_create_subnetworks = false
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_subnetwork" "vpc_subnet" {
+  name          = "custom-subnet"
+  ip_cidr_range = "10.0.0.0/24"
+  network       = google_compute_network.vpc_network.id
+  region        = var.region
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_firewall" "ssh_firewall" {
+  name    = "allow-ssh"
+  network = google_compute_network.vpc_network.id
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+
+  direction = "INGRESS"
+
+  target_tags = ["ssh-access"]
+
+  description = "Allow SSH from anywhere"
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "vm-instance"
+  machine_type = "e2-micro"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.vpc_network.id
+    subnetwork = google_compute_subnetwork.vpc_subnet.id
+
+    access_config {
+      // Ephemeral public IP
+    }
+  }
+
+  tags = ["ssh-access"]
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+
+  depends_on = [
+    google_project_service.compute_api
+  ]
+}
+
+output "instance_name" {
+  value = google_compute_instance.vm_instance.name
+}
+
+output "instance_ip" {
+  value = google_compute_instance.vm_instance.network_interface[0].access_config[0].nat_ip
+}

--- a/vm_instance.tf
+++ b/vm_instance.tf
@@ -1,0 +1,97 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+provider "google" {
+  project = var.project_id
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+
+resource "google_project_service" "compute" {
+  service = "compute.googleapis.com"
+  disable_on_destroy = false
+  project = var.project_id
+}
+
+resource "google_compute_network" "vpc_network" {
+  name = "custom-vpc-network"
+  auto_create_subnetworks = false
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_subnetwork" "subnet" {
+  name          = "custom-subnet"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = "us-central1"
+  network       = google_compute_network.vpc_network.id
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "allow-ssh"
+  network = google_compute_network.vpc_network.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  direction = "INGRESS"
+  target_tags = ["allow-ssh"]
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "vm-instance"
+  machine_type = "e2-micro"
+  zone         = "us-central1-a"
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+
+  tags = ["allow-ssh"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.vpc_network.id
+    subnetwork = google_compute_subnetwork.subnet.id
+
+    access_config {
+      // Ephemeral External IP
+    }
+  }
+  depends_on = [google_project_service.compute]
+}
+
+variable "project_id" {
+  description = "The project ID to deploy resources into"
+  type        = string
+}
+
+output "instance_name" {
+  value = google_compute_instance.vm_instance.name
+}
+
+output "instance_ip" {
+  value = google_compute_instance.vm_instance.network_interface[0].access_config[0].nat_ip
+}


### PR DESCRIPTION
This PR adds a Terraform configuration to create a single e2-micro VM instance running Debian 11 in us-central1-a zone. It also provisions a custom VPC network, a subnet, and a firewall rule that allows SSH access from anywhere. The required API for compute is enabled as well. Resources have "creator = gcp-terraform-agent" label for tracking.