### PR TITLE
Provision GCP VM instance with dedicated VPC, subnet, firewall and external IP

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = ">= 1.0"
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+resource "google_project_service" "compute_api" {
+  project = var.project_id
+  service = "compute.googleapis.com"
+
+  depends_on = [
+    google_project_service.compute_api
+  ]
+}
+
+variable "project_id" {}
+variable "region" {
+  default = "us-central1"
+}
+variable "zone" {
+  default = "us-central1-a"
+}

--- a/resources.tf
+++ b/resources.tf
@@ -1,0 +1,63 @@
+resource "google_compute_network" "custom_vpc" {
+  name                    = "custom-vpc"
+  auto_create_subnetworks = false
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_subnetwork" "custom_subnet" {
+  name          = "custom-subnet"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = var.region
+  network       = google_compute_network.custom_vpc.id
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "allow-ssh"
+  network = google_compute_network.custom_vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+
+  target_tags = ["allow-ssh"]
+  description = "Allow SSH from anywhere"
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "vm-instance"
+  machine_type = "e2-micro"
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.custom_vpc.id
+    subnetwork = google_compute_subnetwork.custom_subnet.id
+
+    access_config {
+      // Ephemeral external IP
+    }
+  }
+
+  tags = ["allow-ssh"]
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,16 @@
+variable "project_id" {
+  description = "The project ID to deploy resources in"
+  type        = string
+}
+
+variable "region" {
+  description = "The region to deploy resources in"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "The zone to deploy resources in"
+  type        = string
+  default     = "us-central1-a"
+}


### PR DESCRIPTION
This PR adds Terraform code to provision a Google Cloud Platform VM instance of type e2-micro in us-central1-a zone with Debian 11 image. It includes:
- Enabling compute.googleapis.com API
- Creating a dedicated VPC and subnet
- Setting up a firewall rule to allow SSH from anywhere
- Assigning external IP to the instance
- Adding label creator = "gcp-terraform-agent" to all resources

The code is organized into main.tf, resources.tf, and variables.tf files.