### PR TITLE
Provision GCP VM Instance with e2-micro, Debian 11, Firewall, VPC, and Subnet

### DIFF
--- a/enable_apis.tf
+++ b/enable_apis.tf
@@ -1,0 +1,13 @@
+resource "google_project_service" "compute_api" {
+  service = "compute.googleapis.com"
+  disable_on_destroy = false
+  project = var.project_id
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+variable "project_id" {
+  description = "The GCP project ID"
+  type = string
+}

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,29 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = ">= 1.1.0"
+}
+
 provider "google" {
   project = var.project_id
-  region  = "us-central1"
-  zone    = "us-central1-a"
+  region  = var.region
+  zone    = var.zone
+}
+
+resource "google_project_service" "compute_api" {
+  project = var.project_id
+  service = "compute.googleapis.com"
+  disable_on_destroy = false
 }
 
 resource "google_compute_network" "custom_vpc" {
   name                    = "custom-vpc"
   auto_create_subnetworks = false
-  description             = "Custom VPC created by terraform"
   labels = {
     creator = "gcp-terraform-agent"
   }
@@ -16,8 +32,9 @@ resource "google_compute_network" "custom_vpc" {
 resource "google_compute_subnetwork" "custom_subnet" {
   name          = "custom-subnet"
   ip_cidr_range = "10.0.0.0/24"
+  region        = var.region
   network       = google_compute_network.custom_vpc.id
-  region        = "us-central1"
+
   labels = {
     creator = "gcp-terraform-agent"
   }
@@ -26,23 +43,28 @@ resource "google_compute_subnetwork" "custom_subnet" {
 resource "google_compute_firewall" "allow_ssh" {
   name    = "allow-ssh"
   network = google_compute_network.custom_vpc.name
+
   allow {
     protocol = "tcp"
     ports    = ["22"]
   }
+
   source_ranges = ["0.0.0.0/0"]
-  direction     = "INGRESS"
-  target_tags   = ["allow-ssh"]
-  description   = "Allow SSH from anywhere"
+
+  target_tags = ["allow-ssh"]
+
+  description = "Allow SSH from anywhere"
+
   labels = {
     creator = "gcp-terraform-agent"
   }
 }
 
 resource "google_compute_instance" "vm_instance" {
-  name         = "terraform-vm-instance"
+  name         = "vm-instance"
   machine_type = "e2-micro"
-  zone         = "us-central1-a"
+  zone         = var.zone
+  tags         = ["allow-ssh"]
 
   boot_disk {
     initialize_params {
@@ -52,21 +74,34 @@ resource "google_compute_instance" "vm_instance" {
 
   network_interface {
     network    = google_compute_network.custom_vpc.id
-    subnetwork = google_compute_subnetwork.custom_subnet.name
-
+    subnetwork = google_compute_subnetwork.custom_subnet.id
     access_config {
-      # Ephemeral external IP
+      // Ephemeral external IP
     }
   }
-
-  tags = ["allow-ssh"]
 
   labels = {
     creator = "gcp-terraform-agent"
   }
+
+  depends_on = [
+    google_project_service.compute_api
+  ]
 }
 
 variable "project_id" {
-  description = "The GCP project ID"
+  description = "GCP Project ID"
   type        = string
+}
+
+variable "region" {
+  description = "GCP Region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "GCP Zone"
+  type        = string
+  default     = "us-central1-a"
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.0"
+      version = ">= 4.0.0"
     }
   }
   required_version = ">= 1.0"
@@ -10,16 +10,15 @@ terraform {
 
 provider "google" {
   project = var.project_id
-  region  = "us-central1"
-  zone    = "us-central1-a"
+  region  = var.region
 }
 
-variable "project_id" {
-  description = "The GCP project ID"
-  type        = string
+resource "google_project_service" "compute_api" {
+  service = "compute.googleapis.com"
+  disable_on_destroy = false
 }
 
-resource "google_compute_network" "custom_network" {
+resource "google_compute_network" "custom_vpc" {
   name                    = "custom-vpc"
   auto_create_subnetworks = false
   labels = {
@@ -30,31 +29,37 @@ resource "google_compute_network" "custom_network" {
 resource "google_compute_subnetwork" "custom_subnet" {
   name          = "custom-subnet"
   ip_cidr_range = "10.0.0.0/24"
-  network       = google_compute_network.custom_network.id
-  region        = "us-central1"
+  region        = var.region
+  network       = google_compute_network.custom_vpc.id
   labels = {
     creator = "gcp-terraform-agent"
   }
 }
 
-resource "google_compute_firewall" "default_allow_ssh" {
+resource "google_compute_firewall" "allow_ssh" {
   name    = "allow-ssh"
-  network = google_compute_network.custom_network.name
+  network = google_compute_network.custom_vpc.name
+
   allow {
     protocol = "tcp"
     ports    = ["22"]
   }
+
   source_ranges = ["0.0.0.0/0"]
-  direction     = "INGRESS"
+
+  target_tags = ["allow-ssh"]
+
+  description = "Allow SSH from anywhere"
+
   labels = {
     creator = "gcp-terraform-agent"
   }
 }
 
 resource "google_compute_instance" "vm_instance" {
-  name         = "debian-vm"
+  name         = "vm-instance"
   machine_type = "e2-micro"
-  zone         = "us-central1-a"
+  zone         = var.zone
 
   boot_disk {
     initialize_params {
@@ -63,19 +68,32 @@ resource "google_compute_instance" "vm_instance" {
   }
 
   network_interface {
-    network    = google_compute_network.custom_network.id
+    network    = google_compute_network.custom_vpc.id
     subnetwork = google_compute_subnetwork.custom_subnet.id
 
     access_config {}
   }
+
+  tags = ["allow-ssh"]
 
   labels = {
     creator = "gcp-terraform-agent"
   }
 }
 
-resource "google_project_service" "compute_api" {
-  service = "compute.googleapis.com"
-  disable_on_destroy = false
-  depends_on = [google_compute_network.custom_network]
+variable "project_id" {
+  description = "The project ID to deploy resources"
+  type        = string
+}
+
+variable "region" {
+  description = "The region to host the VM"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "The zone to host the VM"
+  type        = string
+  default     = "us-central1-a"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,26 +1,13 @@
-terraform {
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = ">= 4.0.0"
-    }
-  }
-  required_version = ">= 1.0"
-}
-
 provider "google" {
   project = var.project_id
-  region  = var.region
-}
-
-resource "google_project_service" "compute_api" {
-  service = "compute.googleapis.com"
-  disable_on_destroy = false
+  region  = "us-central1"
+  zone    = "us-central1-a"
 }
 
 resource "google_compute_network" "custom_vpc" {
   name                    = "custom-vpc"
   auto_create_subnetworks = false
+  description             = "Custom VPC created by terraform"
   labels = {
     creator = "gcp-terraform-agent"
   }
@@ -29,8 +16,8 @@ resource "google_compute_network" "custom_vpc" {
 resource "google_compute_subnetwork" "custom_subnet" {
   name          = "custom-subnet"
   ip_cidr_range = "10.0.0.0/24"
-  region        = var.region
   network       = google_compute_network.custom_vpc.id
+  region        = "us-central1"
   labels = {
     creator = "gcp-terraform-agent"
   }
@@ -39,27 +26,23 @@ resource "google_compute_subnetwork" "custom_subnet" {
 resource "google_compute_firewall" "allow_ssh" {
   name    = "allow-ssh"
   network = google_compute_network.custom_vpc.name
-
   allow {
     protocol = "tcp"
     ports    = ["22"]
   }
-
   source_ranges = ["0.0.0.0/0"]
-
-  target_tags = ["allow-ssh"]
-
-  description = "Allow SSH from anywhere"
-
+  direction     = "INGRESS"
+  target_tags   = ["allow-ssh"]
+  description   = "Allow SSH from anywhere"
   labels = {
     creator = "gcp-terraform-agent"
   }
 }
 
 resource "google_compute_instance" "vm_instance" {
-  name         = "vm-instance"
+  name         = "terraform-vm-instance"
   machine_type = "e2-micro"
-  zone         = var.zone
+  zone         = "us-central1-a"
 
   boot_disk {
     initialize_params {
@@ -69,9 +52,11 @@ resource "google_compute_instance" "vm_instance" {
 
   network_interface {
     network    = google_compute_network.custom_vpc.id
-    subnetwork = google_compute_subnetwork.custom_subnet.id
+    subnetwork = google_compute_subnetwork.custom_subnet.name
 
-    access_config {}
+    access_config {
+      # Ephemeral external IP
+    }
   }
 
   tags = ["allow-ssh"]
@@ -82,18 +67,6 @@ resource "google_compute_instance" "vm_instance" {
 }
 
 variable "project_id" {
-  description = "The project ID to deploy resources"
+  description = "The GCP project ID"
   type        = string
-}
-
-variable "region" {
-  description = "The region to host the VM"
-  type        = string
-  default     = "us-central1"
-}
-
-variable "zone" {
-  description = "The zone to host the VM"
-  type        = string
-  default     = "us-central1-a"
 }

--- a/main.tf
+++ b/main.tf
@@ -5,29 +5,77 @@ terraform {
       version = "~> 4.0"
     }
   }
-
   required_version = ">= 1.0"
 }
 
 provider "google" {
   project = var.project_id
-  region  = var.region
-  zone    = var.zone
+  region  = "us-central1"
+  zone    = "us-central1-a"
+}
+
+variable "project_id" {
+  description = "The GCP project ID"
+  type        = string
+}
+
+resource "google_compute_network" "custom_network" {
+  name                    = "custom-vpc"
+  auto_create_subnetworks = false
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_subnetwork" "custom_subnet" {
+  name          = "custom-subnet"
+  ip_cidr_range = "10.0.0.0/24"
+  network       = google_compute_network.custom_network.id
+  region        = "us-central1"
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_firewall" "default_allow_ssh" {
+  name    = "allow-ssh"
+  network = google_compute_network.custom_network.name
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+  source_ranges = ["0.0.0.0/0"]
+  direction     = "INGRESS"
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "debian-vm"
+  machine_type = "e2-micro"
+  zone         = "us-central1-a"
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.custom_network.id
+    subnetwork = google_compute_subnetwork.custom_subnet.id
+
+    access_config {}
+  }
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
 }
 
 resource "google_project_service" "compute_api" {
-  project = var.project_id
   service = "compute.googleapis.com"
-
-  depends_on = [
-    google_project_service.compute_api
-  ]
-}
-
-variable "project_id" {}
-variable "region" {
-  default = "us-central1"
-}
-variable "zone" {
-  default = "us-central1-a"
+  disable_on_destroy = false
+  depends_on = [google_compute_network.custom_network]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+
+  required_version = ">= 1.0"
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+  zone    = var.zone
+}
+
+resource "google_project_service" "compute_api" {
+  project = var.project_id
+  service = "compute.googleapis.com"
+
+  depends_on = [
+    google_project_service.compute_api
+  ]
+}
+
+variable "project_id" {}
+variable "region" {
+  default = "us-central1"
+}
+variable "zone" {
+  default = "us-central1-a"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_name" {
+  description = "Name of the VM instance"
+  value       = google_compute_instance.vm_instance.name
+}
+
+output "instance_external_ip" {
+  description = "External IP address of the VM instance"
+  value       = google_compute_instance.vm_instance.network_interface[0].access_config[0].nat_ip
+}

--- a/resources.tf
+++ b/resources.tf
@@ -1,0 +1,63 @@
+resource "google_compute_network" "custom_vpc" {
+  name                    = "custom-vpc"
+  auto_create_subnetworks = false
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_subnetwork" "custom_subnet" {
+  name          = "custom-subnet"
+  ip_cidr_range = "10.0.0.0/24"
+  region        = var.region
+  network       = google_compute_network.custom_vpc.id
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_firewall" "allow_ssh" {
+  name    = "allow-ssh"
+  network = google_compute_network.custom_vpc.name
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+
+  target_tags = ["allow-ssh"]
+  description = "Allow SSH from anywhere"
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = "vm-instance"
+  machine_type = "e2-micro"
+  zone         = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network    = google_compute_network.custom_vpc.id
+    subnetwork = google_compute_subnetwork.custom_subnet.id
+
+    access_config {
+      // Ephemeral external IP
+    }
+  }
+
+  tags = ["allow-ssh"]
+
+  labels = {
+    creator = "gcp-terraform-agent"
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,16 @@
 variable "project_id" {
-  description = "The ID of the project in which to provision resources."
+  description = "GCP Project ID"
   type        = string
 }
 
 variable "region" {
-  description = "The GCP region where resources will be created."
+  description = "GCP Region"
   type        = string
   default     = "us-central1"
 }
 
 variable "zone" {
-  description = "The GCP zone where VM instance will be created."
+  description = "GCP Zone"
   type        = string
   default     = "us-central1-a"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,16 @@
+variable "project_id" {
+  description = "The project ID to deploy resources in"
+  type        = string
+}
+
+variable "region" {
+  description = "The region to deploy resources in"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "zone" {
+  description = "The zone to deploy resources in"
+  type        = string
+  default     = "us-central1-a"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,16 +1,16 @@
 variable "project_id" {
-  description = "The project ID to deploy resources in"
+  description = "The ID of the project in which to provision resources."
   type        = string
 }
 
 variable "region" {
-  description = "The region to deploy resources in"
+  description = "The GCP region where resources will be created."
   type        = string
   default     = "us-central1"
 }
 
 variable "zone" {
-  description = "The zone to deploy resources in"
+  description = "The GCP zone where VM instance will be created."
   type        = string
   default     = "us-central1-a"
 }


### PR DESCRIPTION
This pull request adds Terraform configurations for provisioning a Google Cloud Platform VM instance with the following features:

- VM instance of type e2-micro in the us-central1-a zone
- Debian 11 image from debian-cloud
- External IP assigned to the VM
- Firewall rule allowing SSH (port 22) access from anywhere
- Dedicated custom VPC and subnet provisioned
- Labels with creator = "gcp-terraform-agent" added to all resources
- Required API (compute.googleapis.com) enabled

Includes main.tf and variables.tf files for defining resources and input variables respectively.